### PR TITLE
Initial support/tests for SQLite flags and db dump

### DIFF
--- a/spec/database_spec.cr
+++ b/spec/database_spec.cr
@@ -40,8 +40,8 @@ describe Database do
       db.execute "create table person (name string, age integer)"
       db.execute "insert into person values (\"foo\", 10)"
       in_memory_db = Database.new("file:memdb1?mode=memory&cache=shared",
-        LibSQLite3::Flag::URI | LibSQLite3::Flag::CREATE | LibSQLite3::Flag::READWRITE |
-          LibSQLite3::Flag::FULLMUTEX)
+        SQLite3::Flag::URI | SQLite3::Flag::CREATE | SQLite3::Flag::READWRITE |
+          SQLite3::Flag::FULLMUTEX)
       source_rows = db.execute "select * from person"
 
       db.dump(in_memory_db)

--- a/src/sqlite3/database.cr
+++ b/src/sqlite3/database.cr
@@ -14,7 +14,7 @@
 class SQLite3::Database
   # Creates a new Database object that opens the given file.
   def initialize(filename)
-    code = LibSQLite3.open_v2(filename, out @db, (LibSQLite3::Flag::READWRITE | LibSQLite3::Flag::CREATE), nil)
+    code = LibSQLite3.open_v2(filename, out @db, (SQLite3::Flag::READWRITE | SQLite3::Flag::CREATE), nil)
     if code != 0
       raise Exception.new(@db)
     end
@@ -23,7 +23,7 @@ class SQLite3::Database
 
   # Allows for initialization with specific flags. Primary use case is to allow
   # for sqlite3 URI opening and in memory DB operations.
-  def initialize(filename, flags : LibSQLite3::Flag)
+  def initialize(filename, flags : SQLite3::Flag)
     code = LibSQLite3.open_v2(filename, out @db, flags, nil)
     if code != 0
       raise Exception.new(@db)

--- a/src/sqlite3/flags.cr
+++ b/src/sqlite3/flags.cr
@@ -1,0 +1,22 @@
+enum SQLite3::Flag
+  READONLY       = 0x00000001 # Ok for sqlite3_open_v2()
+  READWRITE      = 0x00000002 # Ok for sqlite3_open_v2()
+  CREATE         = 0x00000004 # Ok for sqlite3_open_v2()
+  DELETEONCLOSE  = 0x00000008 # VFS only
+  EXCLUSIVE      = 0x00000010 # VFS only
+  AUTOPROXY      = 0x00000020 # VFS only
+  URI            = 0x00000040 # Ok for sqlite3_open_v2()
+  MEMORY         = 0x00000080 # Ok for sqlite3_open_v2()
+  MAIN_DB        = 0x00000100 # VFS only
+  TEMP_DB        = 0x00000200 # VFS only
+  TRANSIENT_DB   = 0x00000400 # VFS only
+  MAIN_JOURNAL   = 0x00000800 # VFS only
+  TEMP_JOURNAL   = 0x00001000 # VFS only
+  SUBJOURNAL     = 0x00002000 # VFS only
+  MASTER_JOURNAL = 0x00004000 # VFS only
+  NOMUTEX        = 0x00008000 # Ok for sqlite3_open_v2()
+  FULLMUTEX      = 0x00010000 # Ok for sqlite3_open_v2()
+  SHAREDCACHE    = 0x00020000 # Ok for sqlite3_open_v2()
+  PRIVATECACHE   = 0x00040000 # Ok for sqlite3_open_v2()
+  WAL            = 0x00080000 # VFS only
+end

--- a/src/sqlite3/lib_sqlite3.cr
+++ b/src/sqlite3/lib_sqlite3.cr
@@ -4,6 +4,7 @@ require "./type"
 lib LibSQLite3
   type SQLite3 = Void*
   type Statement = Void*
+  type SQLite3Backup = Void*
 
   enum Flag
     READONLY         = 0x00000001  # Ok for sqlite3_open_v2()
@@ -29,6 +30,7 @@ lib LibSQLite3
   end
 
   enum Code
+    OKAY = 0
     ROW = 100
     DONE = 101
   end
@@ -40,6 +42,10 @@ lib LibSQLite3
 
   fun errcode = sqlite3_errcode(SQLite3) : Int32
   fun errmsg = sqlite3_errmsg(SQLite3) : UInt8*
+
+  fun backup_init = sqlite3_backup_init(SQLite3, UInt8*, SQLite3, UInt8*) : SQLite3Backup
+  fun backup_step = sqlite3_backup_step(SQLite3Backup, Int8): Code
+  fun backup_finish = sqlite3_backup_finish(SQLite3Backup): Code
 
   fun prepare_v2 = sqlite3_prepare_v2(db : SQLite3, zSql : UInt8*, nByte : Int32, ppStmt : Statement*, pzTail : UInt8**) : Int32
   fun step = sqlite3_step(stmt : Statement) : Int32

--- a/src/sqlite3/lib_sqlite3.cr
+++ b/src/sqlite3/lib_sqlite3.cr
@@ -6,46 +6,23 @@ lib LibSQLite3
   type Statement = Void*
   type SQLite3Backup = Void*
 
-  enum Flag
-    READONLY         = 0x00000001  # Ok for sqlite3_open_v2()
-    READWRITE        = 0x00000002  # Ok for sqlite3_open_v2()
-    CREATE           = 0x00000004  # Ok for sqlite3_open_v2()
-    DELETEONCLOSE    = 0x00000008  # VFS only
-    EXCLUSIVE        = 0x00000010  # VFS only
-    AUTOPROXY        = 0x00000020  # VFS only
-    URI              = 0x00000040  # Ok for sqlite3_open_v2()
-    MEMORY           = 0x00000080  # Ok for sqlite3_open_v2()
-    MAIN_DB          = 0x00000100  # VFS only
-    TEMP_DB          = 0x00000200  # VFS only
-    TRANSIENT_DB     = 0x00000400  # VFS only
-    MAIN_JOURNAL     = 0x00000800  # VFS only
-    TEMP_JOURNAL     = 0x00001000  # VFS only
-    SUBJOURNAL       = 0x00002000  # VFS only
-    MASTER_JOURNAL   = 0x00004000  # VFS only
-    NOMUTEX          = 0x00008000  # Ok for sqlite3_open_v2()
-    FULLMUTEX        = 0x00010000  # Ok for sqlite3_open_v2()
-    SHAREDCACHE      = 0x00020000  # Ok for sqlite3_open_v2()
-    PRIVATECACHE     = 0x00040000  # Ok for sqlite3_open_v2()
-    WAL              = 0x00080000  # VFS only
-  end
-
   enum Code
-    OKAY = 0
-    ROW = 100
+    OKAY =   0
+    ROW  = 100
     DONE = 101
   end
 
   alias Callback = (Void*, Int32, UInt8**, UInt8**) -> Int32
 
   fun open = sqlite3_open_v2(filename : UInt8*, db : SQLite3*) : Int32
-  fun open_v2 = sqlite3_open_v2(filename : UInt8*, db : SQLite3*, flags: Flag, zVfs : UInt8*) : Int32
+  fun open_v2 = sqlite3_open_v2(filename : UInt8*, db : SQLite3*, flags : SQLite3::Flag, zVfs : UInt8*) : Int32
 
   fun errcode = sqlite3_errcode(SQLite3) : Int32
   fun errmsg = sqlite3_errmsg(SQLite3) : UInt8*
 
   fun backup_init = sqlite3_backup_init(SQLite3, UInt8*, SQLite3, UInt8*) : SQLite3Backup
-  fun backup_step = sqlite3_backup_step(SQLite3Backup, Int8): Code
-  fun backup_finish = sqlite3_backup_finish(SQLite3Backup): Code
+  fun backup_step = sqlite3_backup_step(SQLite3Backup, Int8) : Code
+  fun backup_finish = sqlite3_backup_finish(SQLite3Backup) : Code
 
   fun prepare_v2 = sqlite3_prepare_v2(db : SQLite3, zSql : UInt8*, nByte : Int32, ppStmt : Statement*, pzTail : UInt8**) : Int32
   fun step = sqlite3_step(stmt : Statement) : Int32


### PR DESCRIPTION
This commit adds a pass through for specifying SQLite3 flags. This is
an absolute requirement for being able to create in-memory DB
representations.